### PR TITLE
Add ScriptCommand struct (NSMBU)

### DIFF
--- a/data/nsmb2_intro.md
+++ b/data/nsmb2_intro.md
@@ -4,8 +4,8 @@ Thanks to [Bent](https://github.com/RicBent) for helping with research in this g
 
 Scripts are initially empty, and are initialized in the static init function at 0x004D18F8. Commands are read and executed by the `BsEventMgr` process. The `BsSequenceMgr` process is also involved in some way.
 
-The scripts table is at 0x00570780, and is an array of 39 of the following: `{uint32_t priority; void *script_ptr}`. Scripts are executed using a priority queue, so if multiple scripts are triggered at the same time, they'll execute in order of descending priority.
+The scripts table is at 0x00570780, and is an array of 39 of the following: `{uint32_t priority; ScriptCommand *script_ptr}` with `ScriptCommand` (unofficial name) having the same format as NSMBW, being `{uint32_t command_id; uint32_t argument}` Scripts are executed using a priority queue, so if multiple scripts are triggered at the same time, they'll execute in order of descending priority.
 
-Script commands are the same format as NSMBW: `{uint32_t command_id; uint32_t argument}`... though the arguments are always 0 in this game and nothing seems to read them. The terminator command to end a script is 46.
+The arguments in ScriptCommand are always 0 in this game and nothing seems to read them. The terminator command to end a script is 46.
 
 The script names in the table below are unofficial.

--- a/data/nsmbu_intro.md
+++ b/data/nsmbu_intro.md
@@ -6,7 +6,7 @@ Thanks to [Kinnay](https://github.com/kinnay), [Luminyx](https://github.com/Lumi
 
 Command IDs (but not arguments, strangely) are empty in the static RPX data, and are filled in at runtime by the static init function at 0x021DAB60. Commands are read by the class with constructor at 0x021DC720 (unofficially, "CsEventMgr"). The `イベントアシスタント` ("Event Assistant") actor is also involved in some way, and might be responsible for executing the events.
 
-The scripts table is at 0x10044A60, and is an array of 119 of the following: `{uint32_t priority; void *script_ptr}`. Scripts are executed using a priority queue, so if multiple scripts are triggered at the same time, they'll execute in order of descending priority.
+The scripts table is at 0x10044A60, and is an array of 119 of the following: `{uint32_t priority; ScriptCommand *script_ptr}` with ScriptCommand being `{uint32_t type, uint32_t, arg}`. Scripts are executed using a priority queue, so if multiple scripts are triggered at the same time, they'll execute in order of descending priority.
 
 Script commands are the same format as NSMBW: `{uint32_t command_id; uint32_t argument}`. The terminator command to end a script is 341.
 

--- a/data/nsmbu_intro.md
+++ b/data/nsmbu_intro.md
@@ -6,9 +6,9 @@ Thanks to [Kinnay](https://github.com/kinnay), [Luminyx](https://github.com/Lumi
 
 Command IDs (but not arguments, strangely) are empty in the static RPX data, and are filled in at runtime by the static init function at 0x021DAB60. Commands are read by the class with constructor at 0x021DC720 (unofficially, "CsEventMgr"). The `イベントアシスタント` ("Event Assistant") actor is also involved in some way, and might be responsible for executing the events.
 
-The scripts table is at 0x10044A60, and is an array of 119 of the following: `{uint32_t priority; ScriptCommand *script_ptr}` with ScriptCommand being `{uint32_t type, uint32_t, arg}`. Scripts are executed using a priority queue, so if multiple scripts are triggered at the same time, they'll execute in order of descending priority.
+The scripts table is at 0x10044A60, and is an array of 119 of the following: `{uint32_t priority; ScriptCommand *script_ptr}` with `ScriptCommand` (unofficial name) having the same format as NSMBW, being `{uint32_t type, uint32_t, arg}`. Scripts are executed using a priority queue, so if multiple scripts are triggered at the same time, they'll execute in order of descending priority.
 
-Script commands are the same format as NSMBW: `{uint32_t command_id; uint32_t argument}`. The terminator command to end a script is 341.
+The terminator command to end a script is 341.
 
 The script names in the "Scripts" tables below are unofficial.
 

--- a/data/nsmbu_intro.md
+++ b/data/nsmbu_intro.md
@@ -6,7 +6,7 @@ Thanks to [Kinnay](https://github.com/kinnay), [Luminyx](https://github.com/Lumi
 
 Command IDs (but not arguments, strangely) are empty in the static RPX data, and are filled in at runtime by the static init function at 0x021DAB60. Commands are read by the class with constructor at 0x021DC720 (unofficially, "CsEventMgr"). The `イベントアシスタント` ("Event Assistant") actor is also involved in some way, and might be responsible for executing the events.
 
-The scripts table is at 0x10044A60, and is an array of 119 of the following: `{uint32_t priority; ScriptCommand *script_ptr}` with `ScriptCommand` (unofficial name) having the same format as NSMBW, being `{uint32_t type, uint32_t, arg}`. Scripts are executed using a priority queue, so if multiple scripts are triggered at the same time, they'll execute in order of descending priority.
+The scripts table is at 0x10044A60, and is an array of 119 of the following: `{uint32_t priority; ScriptCommand *script_ptr}` with `ScriptCommand` (unofficial name) having the same format as NSMBW, being `{uint32_t command_id, uint32_t, argument}`. Scripts are executed using a priority queue, so if multiple scripts are triggered at the same time, they'll execute in order of descending priority.
 
 The terminator command to end a script is 341.
 


### PR DESCRIPTION
For accuracy, the void* in the script table entry struct has been changed to ScriptCommand* with said struct also being documented there.